### PR TITLE
OCaml 5.2 support

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,7 +18,7 @@ jobs:
           - ubuntu-22.04
         ocaml-compiler:
           - 5.1.0
-          - 5.2.0+trunk
+          - ocaml-variants.5.2.0+trunk
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -18,6 +18,7 @@ jobs:
           - ubuntu-22.04
         ocaml-compiler:
           - 5.1.0
+          - 5.2.0+trunk
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
This patch adds OCaml 5.2 support. The main change is to account for the new continuation representation in OCaml 5.2, which represents a continuation as a pair. Legacy support is preserved via the use of the compile-time `MULTICONT52` variable. When toggled code for the new continuation representation is included, otherwise this code is excluded.

Resolves #6.