### PR TITLE
Implicit declaration of memcpy

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -16,15 +16,16 @@ jobs:
       matrix:
         os:
           - ubuntu-22.04
+          - macos-14
         ocaml-compiler:
-          - 5.1.0
+          - 5.1.1
           - ocaml-variants.5.2.0+trunk
 
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2

--- a/lib/multicont_stubs.c
+++ b/lib/multicont_stubs.c
@@ -8,6 +8,8 @@
 #include <caml/misc.h>     // provides [CAMLnoalloc] macro
 #include <caml/version.h>  // provides OCaml versioning macros
 
+#include <string.h>
+
 #ifdef NATIVE_CODE
 #include <caml/stack.h>
 #include <caml/frame_descriptors.h>


### PR DESCRIPTION
ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]

This was failing on macOS (14.4.1) with Apple clang version 15.0.0 (clang-1500.3.9.4).